### PR TITLE
Add check for ChromeOS to fix blockstack/blockstack-browser#1269

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,8 +207,14 @@ module.exports = function(uri, failCb, successCb, unsupportedCb) {
             console.log('openUriUsingFirefox')
             openUriUsingFirefox(uri, failCallback, successCallback);
         } else if (browser.isChrome) {
-            console.log('openUriWithTimeoutHack')
-            openUriWithTimeoutHack(uri, failCallback, successCallback);
+            // Check for ChromeOS
+            if (/\bCrOS\b/.test(navigator.appVersion)) {
+                console.log('unsupported OS')
+                unsupportedCallback()
+            } else {
+                console.log('openUriWithTimeoutHack')
+                openUriWithTimeoutHack(uri, failCallback, successCallback);
+            }
         } else if (browser.isIE) {
             console.log('openUriUsingIEInOlderWindows')
             openUriUsingIEInOlderWindows(uri, failCallback, successCallback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-protocol-detection",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "Detect whether a custom protocol is available in browser (FF, Chrome, IE8, IE9, IE10, IE11, and Edge)",
   "main": "index.js",
   "scripts": {

--- a/protocolcheck.js
+++ b/protocolcheck.js
@@ -1,4 +1,4 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.protocolCheck = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.protocolCheck = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 function _registerEvent(target, eventType, cb) {
     if (target.addEventListener) {
         target.addEventListener(eventType, cb);
@@ -208,8 +208,14 @@ module.exports = function(uri, failCb, successCb, unsupportedCb) {
             console.log('openUriUsingFirefox')
             openUriUsingFirefox(uri, failCallback, successCallback);
         } else if (browser.isChrome) {
-            console.log('openUriWithTimeoutHack')
-            openUriWithTimeoutHack(uri, failCallback, successCallback);
+            // Check for ChromeOS
+            if (/\bCrOS\b/.test(navigator.appVersion)) {
+                console.log('unsupported OS')
+                unsupportedCallback()
+            } else {
+                console.log('openUriWithTimeoutHack')
+                openUriWithTimeoutHack(uri, failCallback, successCallback);
+            }
         } else if (browser.isIE) {
             console.log('openUriUsingIEInOlderWindows')
             openUriUsingIEInOlderWindows(uri, failCallback, successCallback);


### PR DESCRIPTION
Fix blockstack/blockstack-browser#1269

### Details

Use `unsupportedBrowser` when user agent includes `CrOS` (ChromeOS).

### Additional actions required

* Push new version to NPM
* Update version of  `custom-protocol-detection-blockstack` on dependents to `1.1.4`
  * [blockstack/blockstack-js](https://github.com/blockstack/blockstack.js)
  * [blockstack/blockstack.ts](https://github.com/ntzwrk/blockstack.ts)


(Doing a pull request into this branch because I noticed it was the most up to date one)