### PR TITLE
Fix opera

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,8 +144,6 @@ function openUriWithMsLaunchUri(uri, failCb, successCb) {
 }
 
 function checkBrowser() {
-    var isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
-
     function isSafari() {
       var ua = navigator.userAgent.toLowerCase();
       var re = new RegExp("safari");
@@ -155,10 +153,9 @@ function checkBrowser() {
     }
 
     return {
-        isOpera   : isOpera,
         isFirefox : typeof InstallTrigger !== 'undefined',
         isSafari  : isSafari(),
-        isChrome  : !!window.chrome && !isOpera,
+        isChrome  : !!window.chrome,
         isIE      : /*@cc_on!@*/false || !!document.documentMode // At least IE6
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-protocol-detection-blockstack",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Detect whether a custom protocol is available in browser (FF, Chrome, IE8, IE9, IE10, IE11, and Edge)",
   "main": "index.js",
   "scripts": {

--- a/protocolcheck.js
+++ b/protocolcheck.js
@@ -145,8 +145,6 @@ function openUriWithMsLaunchUri(uri, failCb, successCb) {
 }
 
 function checkBrowser() {
-    var isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
-
     function isSafari() {
       var ua = navigator.userAgent.toLowerCase();
       var re = new RegExp("safari");
@@ -156,10 +154,9 @@ function checkBrowser() {
     }
 
     return {
-        isOpera   : isOpera,
         isFirefox : typeof InstallTrigger !== 'undefined',
         isSafari  : isSafari(),
-        isChrome  : !!window.chrome && !isOpera,
+        isChrome  : !!window.chrome,
         isIE      : /*@cc_on!@*/false || !!document.documentMode // At least IE6
     }
 }


### PR DESCRIPTION
Opera uses same implementation as Chromium. No reason to exclude it from working.

Same additional release steps needed as #1:
- Push new version to NPM
- Update version of `custom-protocol-detection-blockstack` on dependents to `1.1.5`
  - blockstack/blockstack-js
  - blockstack/blockstack.ts
